### PR TITLE
created endpoints that call call information based on owner or worker…

### DIFF
--- a/wfmapi/views/projects.py
+++ b/wfmapi/views/projects.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers,viewsets
 from rest_framework.permissions import IsAuthenticated
 from wfmapi.models import Project, Worker, Group
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.response import Response
+
 
 class WorkerBriefSerializer(serializers.ModelSerializer):
 
@@ -61,3 +64,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
     serializer_class = ProjectSerializer
     permission_classes = [IsAuthenticated]
 
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_my_projects(request):
+    worker = Worker.objects.get(user=request.user)
+    projects = Project.objects.filter(workers=worker)
+    serializer = ProjectSerializer(projects, many=True)
+    return Response(serializer.data)

--- a/wfmapi/views/user.py
+++ b/wfmapi/views/user.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 from wfmapi.models import User
 from rest_framework import viewsets
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta: 
@@ -11,3 +14,9 @@ class UserSerializer(serializers.ModelSerializer):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_current_user(request):
+    serializer = UserSerializer(request.user)
+    return Response(serializer.data)

--- a/wfmproject/urls.py
+++ b/wfmproject/urls.py
@@ -3,8 +3,8 @@ from django.urls import include, path
 from rest_framework import routers
 from wfmapi.views import register
 from wfmapi.views import ClientViewSet, GroupViewset, ProjectViewSet, UserViewSet, WorkerViewSet, ProjectWorkerViewSet, GroupWorkerViewSet, ProjectGroupViewSet  
-
-
+from wfmapi.views.user import get_current_user
+from wfmapi.views.projects import get_my_projects
 
 router = routers.DefaultRouter(trailing_slash=False)
 # Register viewsets
@@ -21,5 +21,7 @@ urlpatterns = [
     path('', include(router.urls)),
     path('register', register.register_user),
     path('login', register.login_user),
+    path('users/me/', get_current_user),
+    path('my-projects/', get_my_projects)
 ]
 


### PR DESCRIPTION
Description:
This pull request ensures that the owner and workers only the specific data. By creating Owner and Worker Dashboard files, we can ensure that the main Dashboard.jsx redirects the user to the appropriate dashboard based on their credentials. now, when the owner will be able to have access to full business details while the worker will only be able to read the data but not be able to edit it. 

Changes:
Added OwnderDashboard.jsx, WorkerDashboard.jsx. Changed Dashboard.jsx to send user to appropriate dashboard based on their role within the business. 

Testing:
Owner Dashboard
1. create an owner
2. login
3. if you see a dashboard with all details of the business then you have been sent to the owner dashboard
Worker Dashboard: 
1. create a worker profile
2. login
3. if you are only able to see the project that you a part of and have no edit capabilities then you are in the worker dashboard
